### PR TITLE
Add GitHub Actions automation suite (link checker, arXiv watcher, stale bot)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,11 @@
+# Automation Workflows
+
+This directory contains GitHub Actions workflows that keep the repository healthy automatically.
+
+| Workflow | Schedule | Purpose |
+|---|---|---|
+| `link-checker.yml` | Every Monday | Scans all URLs in README and opens an issue if any are broken |
+| `arxiv-watcher.yml` | Every Wednesday | Searches arXiv for new anomaly detection papers and opens a curated issue |
+| `stale.yml` | Daily | Labels issues/PRs inactive after 60 days, closes after 7 more |
+
+No configuration needed — workflows run automatically once the PR is merged.

--- a/.github/workflows/arxiv-watcher.yml
+++ b/.github/workflows/arxiv-watcher.yml
@@ -1,0 +1,28 @@
+name: arXiv Paper Watcher
+
+on:
+  schedule:
+    - cron: '0 9 * * 3'
+  workflow_dispatch:
+
+jobs:
+  fetch-papers:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Fetch new arXiv papers
+        run: python .github/workflows/arxiv_watcher.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,0 +1,39 @@
+name: Link Checker
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run link checker
+        run: python .github/workflows/url_checker.py
+        continue-on-error: true
+
+      - name: Create issue if broken links found
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Broken links detected',
+              body: 'The weekly link checker found broken URLs. Check the Actions log for details.',
+              labels: ['broken-link']
+            })

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been inactive for 60 days. It will be closed in 7 days
+            unless there is new activity. Thank you for contributing!
+          stale-pr-message: >
+            This pull request has been inactive for 60 days. It will be closed in 7 days
+            unless there is new activity. Thank you for contributing!
+          close-issue-message: >
+            Closing due to inactivity. Feel free to reopen if this is still relevant.
+          close-pr-message: >
+            Closing due to inactivity. Feel free to reopen if this is still relevant.
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale


### PR DESCRIPTION
## What this adds

Three GitHub Actions workflows to automate repository maintenance:

- **Link Checker** (every Monday + on PRs) — scans all URLs and opens an issue if any are broken
- **arXiv Watcher** (every Wednesday) — searches arXiv for new anomaly detection papers and opens a curated issue
- **Stale Bot** (daily) — labels issues/PRs inactive after 60 days, closes after 7 more with friendly messages

No secrets or configuration needed. Everything runs on `GITHUB_TOKEN` which GitHub provides automatically.